### PR TITLE
Support justification of children in `Container`

### DIFF
--- a/examples/container.rs
+++ b/examples/container.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Infallible> {
             inner_container.boxed(),
             text3.boxed(),
         ],
-        justification: Justification::End,
+        justification: Justification::Center,
         ..Default::default()
     });
     container.draw(&mut display, Point::new(20, 20), Size::new(260, 260))?;

--- a/examples/container.rs
+++ b/examples/container.rs
@@ -1,5 +1,5 @@
 use cherry::widget::{
-    container::{Alignment, Border, Container, Options},
+    container::{Alignment, Border, Container, Justification, Options},
     text::{Options as TextOptions, Text},
     Widget,
 };
@@ -40,6 +40,7 @@ fn main() -> Result<(), Infallible> {
             inner_container.boxed(),
             text3.boxed(),
         ],
+        justification: Justification::End,
         ..Default::default()
     });
     container.draw(&mut display, Point::new(20, 20), Size::new(260, 260))?;

--- a/examples/container.rs
+++ b/examples/container.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Infallible> {
             inner_container.boxed(),
             text3.boxed(),
         ],
-        justification: Justification::SpaceEvenly,
+        justification: Justification::SpaceAround,
         ..Default::default()
     });
     container.draw(&mut display, Point::new(20, 20), Size::new(260, 260))?;

--- a/examples/container.rs
+++ b/examples/container.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Infallible> {
             inner_container.boxed(),
             text3.boxed(),
         ],
-        justification: Justification::Center,
+        justification: Justification::SpaceBetween,
         ..Default::default()
     });
     container.draw(&mut display, Point::new(20, 20), Size::new(260, 260))?;

--- a/examples/container.rs
+++ b/examples/container.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Infallible> {
             inner_container.boxed(),
             text3.boxed(),
         ],
-        justification: Justification::SpaceBetween,
+        justification: Justification::SpaceEvenly,
         ..Default::default()
     });
     container.draw(&mut display, Point::new(20, 20), Size::new(260, 260))?;

--- a/src/widget/container/justification.rs
+++ b/src/widget/container/justification.rs
@@ -1,6 +1,7 @@
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub enum Justification {
     Start,
+    Center,
     End,
 }
 

--- a/src/widget/container/justification.rs
+++ b/src/widget/container/justification.rs
@@ -4,6 +4,8 @@ pub enum Justification {
     Center,
     End,
     SpaceBetween,
+    SpaceAround,
+    SpaceEvenly,
 }
 
 impl Default for Justification {

--- a/src/widget/container/justification.rs
+++ b/src/widget/container/justification.rs
@@ -1,0 +1,11 @@
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub enum Justification {
+    Start,
+    End,
+}
+
+impl Default for Justification {
+    fn default() -> Self {
+        Self::Start
+    }
+}

--- a/src/widget/container/justification.rs
+++ b/src/widget/container/justification.rs
@@ -3,6 +3,7 @@ pub enum Justification {
     Start,
     Center,
     End,
+    SpaceBetween,
 }
 
 impl Default for Justification {

--- a/src/widget/container/mod.rs
+++ b/src/widget/container/mod.rs
@@ -121,6 +121,7 @@ where
         let total_children_height = self.content_size().height.unwrap_or(0);
         let mut y: i32 = match self.options.justification {
             Justification::Start => 0,
+            Justification::Center => (size.height - total_children_height) / 2,
             Justification::End => size.height - total_children_height,
         } as i32;
 

--- a/src/widget/container/mod.rs
+++ b/src/widget/container/mod.rs
@@ -118,12 +118,23 @@ where
         origin: Point,
         size: Size,
     ) -> Result<(), Display::Error> {
+        let num_children = self.options.children.len() as u32;
         let total_children_height = self.content_size().height.unwrap_or(0);
-        let mut y: i32 = match self.options.justification {
-            Justification::Start => 0,
-            Justification::Center => (size.height - total_children_height) / 2,
-            Justification::End => size.height - total_children_height,
-        } as i32;
+        let unused_height = size.height - total_children_height;
+
+        let (mut current_y, space_between) = match self.options.justification {
+            Justification::Start => (0, 0),
+            Justification::Center => (unused_height / 2, 0),
+            Justification::End => (unused_height, 0),
+            Justification::SpaceBetween => (
+                0,
+                if num_children > 1 {
+                    unused_height / (num_children - 1)
+                } else {
+                    0
+                },
+            ),
+        };
 
         for child in &self.options.children {
             let child_size = child
@@ -136,9 +147,9 @@ where
                 Alignment::End => size.width - child_size.width,
             };
 
-            let child_origin = Point::new(origin.x + (offset as i32), origin.y + y);
+            let child_origin = Point::new(origin.x + (offset as i32), origin.y + current_y as i32);
             child.draw(display, child_origin, child_size)?;
-            y += child_size.height as i32;
+            current_y += child_size.height + space_between;
         }
 
         Ok(())

--- a/src/widget/container/mod.rs
+++ b/src/widget/container/mod.rs
@@ -119,21 +119,34 @@ where
         size: Size,
     ) -> Result<(), Display::Error> {
         let num_children = self.options.children.len() as u32;
+
+        if num_children == 0 {
+            return Ok(());
+        }
+
         let total_children_height = self.content_size().height.unwrap_or(0);
         let unused_height = size.height - total_children_height;
 
-        let (mut current_y, space_between) = match self.options.justification {
+        let (mut current_y, space) = match self.options.justification {
             Justification::Start => (0, 0),
             Justification::Center => (unused_height / 2, 0),
             Justification::End => (unused_height, 0),
-            Justification::SpaceBetween => (
-                0,
-                if num_children > 1 {
+            Justification::SpaceBetween => {
+                let space = if num_children > 1 {
                     unused_height / (num_children - 1)
                 } else {
                     0
-                },
-            ),
+                };
+                (0, space)
+            }
+            Justification::SpaceAround => {
+                let space = unused_height / num_children;
+                (space / 2, space)
+            }
+            Justification::SpaceEvenly => {
+                let space = unused_height / (num_children + 1);
+                (space, space)
+            }
         };
 
         for child in &self.options.children {
@@ -149,7 +162,7 @@ where
 
             let child_origin = Point::new(origin.x + (offset as i32), origin.y + current_y as i32);
             child.draw(display, child_origin, child_size)?;
-            current_y += child_size.height + space_between;
+            current_y += child_size.height + space;
         }
 
         Ok(())

--- a/src/widget/container/mod.rs
+++ b/src/widget/container/mod.rs
@@ -1,8 +1,10 @@
 mod alignment;
 mod border;
+mod justification;
 
 pub use alignment::Alignment;
 pub use border::Border;
+pub use justification::Justification;
 
 use super::{IntrinsicSize, Widget};
 use alloc::{boxed::Box, vec::Vec};
@@ -21,6 +23,7 @@ where
     pub children: Vec<Box<dyn Widget<Display>>>,
     pub corner_radii: Option<CornerRadii>,
     pub height: Option<u32>,
+    pub justification: Justification,
     pub width: Option<u32>,
 }
 
@@ -33,10 +36,11 @@ where
             alignment: Default::default(),
             background_color: Default::default(),
             border: Default::default(),
-            corner_radii: Default::default(),
-            width: Default::default(),
-            height: Default::default(),
             children: Default::default(),
+            corner_radii: Default::default(),
+            height: Default::default(),
+            justification: Default::default(),
+            width: Default::default(),
         }
     }
 }
@@ -114,7 +118,11 @@ where
         origin: Point,
         size: Size,
     ) -> Result<(), Display::Error> {
-        let mut y: i32 = 0;
+        let total_children_height = self.content_size().height.unwrap_or(0);
+        let mut y: i32 = match self.options.justification {
+            Justification::Start => 0,
+            Justification::End => size.height - total_children_height,
+        } as i32;
 
         for child in &self.options.children {
             let child_size = child


### PR DESCRIPTION
This adds support for equivalents of the flexbox justification types that make sense so far.

## Testing

In `examples/container.rs`, change `justification: Justification::SpaceAround` to try all the enum cases defined in `justification.rs`.