### PR TITLE
Support stretch alignment

### DIFF
--- a/src/widget/container/alignment.rs
+++ b/src/widget/container/alignment.rs
@@ -1,5 +1,6 @@
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub enum Alignment {
+    Stretch,
     Start,
     Center,
     End,
@@ -7,6 +8,6 @@ pub enum Alignment {
 
 impl Default for Alignment {
     fn default() -> Self {
-        Self::Start
+        Self::Stretch
     }
 }

--- a/src/widget/container/mod.rs
+++ b/src/widget/container/mod.rs
@@ -155,11 +155,17 @@ where
         };
 
         for child in &self.options.children {
-            let mut child_size = child.intrinsic_size().to_size_with_defaults(Size::zero());
+            let default_size = match (self.options.alignment, self.main_axis()) {
+                (Alignment::Stretch, Axis::Horizontal) => Size::new(0, size.height),
+                (Alignment::Stretch, Axis::Vertical) => Size::new(size.width, 0),
+                _ => Size::zero(),
+            };
+
+            let mut child_size = child.intrinsic_size().to_size_with_defaults(default_size);
             child_size.add_to_axis(grow_unit * child.grow(), self.main_axis());
 
             let cross_axis_offset = match self.options.alignment {
-                Alignment::Start => 0,
+                Alignment::Stretch | Alignment::Start => 0,
                 Alignment::Center => {
                     (size.for_axis(self.cross_axis()) - child_size.for_axis(self.cross_axis())) / 2
                 }


### PR DESCRIPTION
This tries to mimic the behavior of the stretch alignment in CSS flexbox. In an example where the main axis is vertical:

- stretch alignment
  - widgets with no set width will be drawn will the full width of their parent
  - widgets with a set width will keep that width and be aligned as if the alignment was "start"
- other alignments
  - widgets with no set width will have a width of 0 (so consume vertical space, but not be visible)

Fixes #9.

## Testing

Remove the `width` from `yellow_box` and/or `magenta_box`, and see how that interacts with the different alignments you can set on `container` (try the new `Stretch` alignment).