### PR TITLE
Clip text widget to size

### DIFF
--- a/src/widget/container/mod.rs
+++ b/src/widget/container/mod.rs
@@ -161,7 +161,10 @@ where
                 _ => Size::zero(),
             };
 
-            let mut child_size = child.intrinsic_size().to_size_with_defaults(default_size);
+            let mut child_size = child
+                .intrinsic_size()
+                .to_size_with_defaults(default_size)
+                .component_min(size);
             child_size.add_to_axis(grow_unit * child.grow(), self.main_axis());
 
             let cross_axis_offset = match self.options.alignment {

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -2,6 +2,7 @@ use super::{IntrinsicSize, Widget};
 use embedded_graphics::{
     mono_font::MonoTextStyle,
     prelude::*,
+    primitives::Rectangle,
     text::{self, Baseline},
 };
 
@@ -43,9 +44,10 @@ where
         self.text(Point::zero()).bounding_box().size.into()
     }
 
-    fn draw(&self, display: &mut Display, origin: Point, _: Size) -> Result<(), Display::Error> {
+    fn draw(&self, display: &mut Display, origin: Point, size: Size) -> Result<(), Display::Error> {
         let text = self.text(origin);
-        text.draw(display)?;
+        let mut display = display.clipped(&Rectangle::new(origin, size));
+        text.draw(&mut display)?;
 
         Ok(())
     }


### PR DESCRIPTION
The `Text` widget was ignoring the provided size when drawing, allowing text to escape the expected bounds of the widget.

Fixes #8.

## Testing

Change one of the text widgets in the container example to have very long text (and maybe a more obvious color):

```rs
let character_style = MonoTextStyle::new(&FONT_10X20, Rgb888::RED);
let text1 = Text::new(
    TextOptions { character_style },
    "Line 1 Line 1 Line 1 Line 1 Line 1 Line 1 Line 1 Line 1 Line 1 Line 1 Line 1",
);
```

On this branch, the text will not overflow the bounds of the main container widget. On the parent branch, it will.