### PR TITLE
Support per-child alignment

### DIFF
--- a/examples/container.rs
+++ b/examples/container.rs
@@ -1,7 +1,7 @@
 use cherry::widget::{
     container::{Alignment, Axis, Border, Container, Insets, Justification, Options},
     text::{Options as TextOptions, Text},
-    Widget,
+    LayoutOptions, Widget,
 };
 use embedded_graphics::{
     draw_target::DrawTarget,
@@ -18,8 +18,20 @@ fn main() -> Result<(), Infallible> {
     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(display_size);
 
     let character_style = MonoTextStyle::new(&FONT_10X20, Rgb888::BLACK);
-    let text1 = Text::new(TextOptions { character_style }, "Line 1");
-    let text2 = Text::new(TextOptions { character_style }, "Line 2");
+    let text1 = Text::new(
+        TextOptions {
+            character_style,
+            layout_options: Default::default(),
+        },
+        "Line 1",
+    );
+    let text2 = Text::new(
+        TextOptions {
+            character_style,
+            layout_options: Default::default(),
+        },
+        "Line 2",
+    );
 
     let rgb_swatch = Container::new(Options {
         alignment: Alignment::Center,
@@ -42,14 +54,20 @@ fn main() -> Result<(), Infallible> {
 
     let yellow_box = Container::new(Options {
         background_color: Some(Rgb888::YELLOW),
-        grow: 1,
+        layout_options: LayoutOptions {
+            grow: 1,
+            ..Default::default()
+        },
         width: Some(100),
         ..Default::default()
     });
 
     let magenta_box = Container::new(Options {
         background_color: Some(Rgb888::MAGENTA),
-        grow: 2,
+        layout_options: LayoutOptions {
+            grow: 2,
+            ..Default::default()
+        },
         width: Some(100),
         ..Default::default()
     });

--- a/examples/container.rs
+++ b/examples/container.rs
@@ -55,10 +55,9 @@ fn main() -> Result<(), Infallible> {
     let yellow_box = Container::new(Options {
         background_color: Some(Rgb888::YELLOW),
         layout_options: LayoutOptions {
+            alignment: Some(Alignment::Stretch),
             grow: 1,
-            ..Default::default()
         },
-        width: Some(100),
         ..Default::default()
     });
 

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -14,7 +14,13 @@ fn main() -> Result<(), Infallible> {
     let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(300, 300));
 
     let character_style = MonoTextStyle::new(&FONT_10X20, Rgb888::YELLOW);
-    let widget = Text::new(Options { character_style }, "Hello");
+    let widget = Text::new(
+        Options {
+            character_style,
+            layout_options: Default::default(),
+        },
+        "Hello",
+    );
     widget.draw(&mut display, Point::new(20, 20), Size::new(100, 100))?;
 
     let output_settings = OutputSettingsBuilder::new().build();

--- a/src/widget/container/mod.rs
+++ b/src/widget/container/mod.rs
@@ -160,7 +160,12 @@ where
         };
 
         for child in &self.options.children {
-            let default_size = match (self.options.alignment, self.main_axis()) {
+            let child_alignment = child
+                .layout_options()
+                .alignment
+                .unwrap_or(self.options.alignment);
+
+            let default_size = match (child_alignment, self.main_axis()) {
                 (Alignment::Stretch, Axis::Horizontal) => Size::new(0, size.height),
                 (Alignment::Stretch, Axis::Vertical) => Size::new(size.width, 0),
                 _ => Size::zero(),
@@ -172,7 +177,7 @@ where
                 .component_min(size);
             child_size.add_to_axis(grow_unit * child.layout_options().grow, self.main_axis());
 
-            let cross_axis_offset = match self.options.alignment {
+            let cross_axis_offset = match child_alignment {
                 Alignment::Stretch | Alignment::Start => 0,
                 Alignment::Center => {
                     (size.for_axis(self.cross_axis()) - child_size.for_axis(self.cross_axis())) / 2

--- a/src/widget/container/mod.rs
+++ b/src/widget/container/mod.rs
@@ -124,7 +124,12 @@ where
             self.content_size().for_axis(self.main_axis()).unwrap_or(0);
         let extra_main_axis_dimension =
             size.for_axis(self.main_axis()) - total_children_main_axis_dimension;
-        let grow_total: u32 = self.options.children.iter().map(|child| child.grow()).sum();
+        let grow_total: u32 = self
+            .options
+            .children
+            .iter()
+            .map(|child| child.layout_options().grow)
+            .sum();
 
         let (unused_main_axis_dimension, grow_unit) = if grow_total > 0 {
             (0, extra_main_axis_dimension / grow_total)
@@ -165,7 +170,7 @@ where
                 .intrinsic_size()
                 .to_size_with_defaults(default_size)
                 .component_min(size);
-            child_size.add_to_axis(grow_unit * child.grow(), self.main_axis());
+            child_size.add_to_axis(grow_unit * child.layout_options().grow, self.main_axis());
 
             let cross_axis_offset = match self.options.alignment {
                 Alignment::Stretch | Alignment::Start => 0,
@@ -213,8 +218,8 @@ where
         )
     }
 
-    fn grow(&self) -> u32 {
-        self.options.grow
+    fn layout_options(&self) -> super::LayoutOptions {
+        self.options.layout_options
     }
 
     fn draw(&self, display: &mut Display, origin: Point, size: Size) -> Result<(), Display::Error> {

--- a/src/widget/container/options.rs
+++ b/src/widget/container/options.rs
@@ -1,5 +1,5 @@
 use super::{Alignment, Axis, Border, Insets, Justification};
-use crate::widget::Widget;
+use crate::widget::{LayoutOptions, Widget};
 use alloc::{boxed::Box, vec::Vec};
 use embedded_graphics::{draw_target::DrawTarget, primitives::CornerRadii};
 
@@ -13,9 +13,9 @@ where
     pub border: Option<Border<Display::Color>>,
     pub children: Vec<Box<dyn Widget<Display>>>,
     pub corner_radii: Option<CornerRadii>,
-    pub grow: u32,
     pub height: Option<u32>,
     pub justification: Justification,
+    pub layout_options: LayoutOptions,
     pub margin: Insets,
     pub padding: Insets,
     pub width: Option<u32>,
@@ -33,9 +33,9 @@ where
             border: Default::default(),
             children: Default::default(),
             corner_radii: Default::default(),
-            grow: Default::default(),
             height: Default::default(),
             justification: Default::default(),
+            layout_options: Default::default(),
             margin: Default::default(),
             padding: Default::default(),
             width: Default::default(),

--- a/src/widget/layout_options.rs
+++ b/src/widget/layout_options.rs
@@ -1,0 +1,4 @@
+#[derive(Clone, Copy, Default)]
+pub struct LayoutOptions {
+    pub grow: u32,
+}

--- a/src/widget/layout_options.rs
+++ b/src/widget/layout_options.rs
@@ -1,4 +1,7 @@
+use super::container::Alignment;
+
 #[derive(Clone, Copy, Default)]
 pub struct LayoutOptions {
+    pub alignment: Option<Alignment>,
     pub grow: u32,
 }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -4,8 +4,10 @@ pub mod text;
 
 mod axis_size;
 mod intrinsic_size;
+mod layout_options;
 
 pub use intrinsic_size::IntrinsicSize;
+pub use layout_options::LayoutOptions;
 
 use alloc::boxed::Box;
 use embedded_graphics::prelude::*;
@@ -13,8 +15,8 @@ use embedded_graphics::prelude::*;
 pub trait Widget<Display: DrawTarget> {
     fn intrinsic_size(&self) -> IntrinsicSize;
 
-    fn grow(&self) -> u32 {
-        0
+    fn layout_options(&self) -> LayoutOptions {
+        LayoutOptions::default()
     }
 
     fn draw(&self, display: &mut Display, origin: Point, size: Size) -> Result<(), Display::Error>;

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -1,4 +1,4 @@
-use super::{IntrinsicSize, Widget};
+use super::{IntrinsicSize, LayoutOptions, Widget};
 use embedded_graphics::{
     mono_font::MonoTextStyle,
     prelude::*,
@@ -9,6 +9,7 @@ use embedded_graphics::{
 #[derive(Clone, Copy)]
 pub struct Options<'font, Color> {
     pub character_style: MonoTextStyle<'font, Color>,
+    pub layout_options: LayoutOptions,
 }
 
 #[derive(Clone, Copy)]
@@ -44,7 +45,11 @@ where
         self.text(Point::zero()).bounding_box().size.into()
     }
 
-    fn draw(&self, display: &mut Display, origin: Point, size: Size) -> Result<(), Display::Error> {
+    fn layout_options(&self) -> LayoutOptions {
+        self.options.layout_options
+    }
+
+    fn draw(&self, display: &mut Display, origin: Point, _: Size) -> Result<(), Display::Error> {
         let text = self.text(origin);
         let mut display = display.clipped(&Rectangle::new(origin, size));
         text.draw(&mut display)?;

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -49,7 +49,7 @@ where
         self.options.layout_options
     }
 
-    fn draw(&self, display: &mut Display, origin: Point, _: Size) -> Result<(), Display::Error> {
+    fn draw(&self, display: &mut Display, origin: Point, size: Size) -> Result<(), Display::Error> {
         let text = self.text(origin);
         let mut display = display.clipped(&Rectangle::new(origin, size));
         text.draw(&mut display)?;


### PR DESCRIPTION
This is equivalent to `align-self` from flexbox.

Fixes #19.